### PR TITLE
ci: deploy to server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,9 +47,12 @@ jobs:
         with:
           path: src/.vitepress/dist
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: src/.vitepress/dist
-          publish_branch: gh-pages
+      - name: Deploy to Server
+        uses: easingthemes/ssh-deploy@main
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_KEY }}
+          REMOTE_HOST: ${{ secrets.DEPLOY_HOST }}
+          REMOTE_USER: ${{ secrets.DEPLOY_USERNAME }}
+          TARGET: ${{ secrets.DEPLOY_PATH }}
+          SOURCE: src/.vitepress/dist
+          # ARGS: -avzr --delete


### PR DESCRIPTION
## Summary by Sourcery

部署：
- 将站点部署方式从 GitHub Pages 切换为基于 SSH 的部署，并部署到可配置的远程服务器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Deployment:
- Switch site deployment from GitHub Pages to an SSH-based deployment to a configurable remote server.

</details>